### PR TITLE
feat: add secondary auth fallback mechanism

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Kuckkuck @timojohlo @olandr @joluc

--- a/prometheus_es_exporter/__init__.py
+++ b/prometheus_es_exporter/__init__.py
@@ -405,7 +405,7 @@ CONFIGPARSER_CONVERTERS = {
 def create_es_client(es_cluster, ca_certs, client_cert, client_key, headers,
                      headers_failover, http_auth, http_auth_failover, verify_certs=True):
     """
-    Create an Elasticsearch client with the provided parameters.
+    Create an Elasticsearch client with primary and failover credentials.
     """
     def instantiate_client(auth, current_headers):
         if ca_certs:

--- a/prometheus_es_exporter/__init__.py
+++ b/prometheus_es_exporter/__init__.py
@@ -449,6 +449,13 @@ def create_es_client(es_cluster, ca_certs, client_cert, client_key, headers,
 
     return es_client
 
+def set_auth(user, password):
+    if user and password is None:
+        raise click.BadOptionUsage(user, 'Username provided with no password.')
+    elif user is None and password:
+      raise click.BadOptionUsage(password, 'Password provided with no username.')
+
+    return (user, password) if user else None
 
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.option('--es-cluster', '-e', default='localhost',
@@ -570,17 +577,9 @@ def create_es_client(es_cluster, ca_certs, client_cert, client_key, headers,
 @click_config_file.configuration_option()
 def cli(**options):
     """Export Elasticsearch query results to Prometheus."""
-    if options['basic_user'] and options['basic_password'] is None:
-        raise click.BadOptionUsage('basic_user', 'Username provided with no password.')
-    elif options['basic_user'] is None and options['basic_password']:
-        raise click.BadOptionUsage('basic_password', 'Password provided with no username.')
-    http_auth = (options['basic_user'], options['basic_password']) if options['basic_user'] else None
 
-    if options['failover_basic_user'] and options['failover_basic_password'] is None:
-        raise click.BadOptionUsage('failover_basic_user', 'Secondary username provided with no password.')
-    elif options['failover_basic_user'] is None and options['failover_basic_password']:
-        raise click.BadOptionUsage('failover_basic_password', 'Secondary password provided with no username.')
-    http_auth_failover = (options['failover_basic_user'], options['failover_basic_password']) if options['failover_basic_user'] else None
+    http_auth = set_auth(options['basic_user'], options['basic_password'])
+    http_auth_failover = set_auth(options['failover_basic_user'], options['failover_basic_password'])
 
     if not options['ca_certs'] and options['client_cert']:
         raise click.BadOptionUsage('client_cert',

--- a/prometheus_es_exporter/__init__.py
+++ b/prometheus_es_exporter/__init__.py
@@ -426,17 +426,26 @@ def create_es_client(es_cluster, ca_certs, client_cert, client_key, headers,
                 http_auth=auth
             )
 
+    def check_cluster_health(client):
+        try:
+            # Checking the _cluster/health endpoint (GET request)
+            health = client.cluster.health(request_timeout=10)
+            return True
+        except Exception as e:
+            log.error("Cluster health check failed: %s", e)
+            return False
+
     es_client = instantiate_client(http_auth, headers)
     try:
-        if not es_client.ping():
-            raise Exception("Ping failed for auth credentials.")
+        if not check_cluster_health(es_client):
+            raise Exception("Cluster health check failed for auth credentials.")
     except Exception as e:
-        log.warning("Authentication failed: %s", e)
+        log.error("Authentication failed: %s", e)
         if http_auth_failover:
-            log.info("Falling back to failover auth credentials.")
+            log.error("Falling back to failover auth credentials.")
             es_client = instantiate_client(http_auth_failover, headers_failover)
-            if not es_client.ping():
-                raise Exception("Ping failed for failover credentials as well.")
+            if not check_cluster_health(es_client):
+                raise Exception("Cluster health check failed for failover credentials as well. Abort!")
         else:
             # No secondary credentials provided
             raise

--- a/prometheus_es_exporter/__init__.py
+++ b/prometheus_es_exporter/__init__.py
@@ -403,11 +403,11 @@ CONFIGPARSER_CONVERTERS = {
 }
 
 def create_es_client(es_cluster, ca_certs, client_cert, client_key, headers,
-                     http_auth, http_auth_failover, verify_certs=True):
+                     headers_failover, http_auth, http_auth_failover, verify_certs=True):
     """
     Create an Elasticsearch client with the provided parameters.
     """
-    def instantiate_client(auth):
+    def instantiate_client(auth, current_headers):
         if ca_certs:
             return Elasticsearch(
                 es_cluster,
@@ -415,28 +415,28 @@ def create_es_client(es_cluster, ca_certs, client_cert, client_key, headers,
                 ca_certs=ca_certs,
                 client_cert=client_cert,
                 client_key=client_key,
-                headers=headers,
+                headers=current_headers,
                 http_auth=auth
             )
         else:
             return Elasticsearch(
                 es_cluster,
                 verify_certs=verify_certs,
-                headers=headers,
+                headers=current_headers,
                 http_auth=auth
             )
 
-    es_client = instantiate_client(http_auth)
+    es_client = instantiate_client(http_auth, headers)
     try:
         if not es_client.ping():
-            raise Exception("Ping failed for basic auth credentials.")
+            raise Exception("Ping failed for auth credentials.")
     except Exception as e:
         log.warning("Authentication failed: %s", e)
         if http_auth_failover:
-            log.info("Falling back to failover basic auth credentials.")
-            es_client = instantiate_client(http_auth_failover)
+            log.info("Falling back to failover auth credentials.")
+            es_client = instantiate_client(http_auth_failover, headers_failover)
             if not es_client.ping():
-                raise Exception("Ping failed for failover basic auth credentials as well.")
+                raise Exception("Ping failed for failover credentials as well.")
         else:
             # No secondary credentials provided
             raise
@@ -483,6 +483,13 @@ def create_es_client(es_cluster, ca_certs, client_cert, client_key, headers,
                    'Header name and value should be separated by colon, e.g. '
                    '"Authorization: Bearer xxxxx". Several headers can be added '
                    'by repeating the -H parameter.')
+@click.option('--failover-header',
+              multiple=True,
+              callback=http_headers_parser,
+              help='Failover HTTP header to include in requests to the Elasticsearch cluster. '
+                   'Header name and value should be separated by colon, e.g. '
+                   '"Authorization: Bearer xxxxx". Several headers can be added '
+                   'by repeating the --failover-header parameter.')
 @click.option('--port', '-p', default=9206,
               help='Port to serve the metrics endpoint on. (default: 9206)')
 @click.option('--query-disable', default=False, is_flag=True,
@@ -563,9 +570,9 @@ def cli(**options):
         raise click.BadOptionUsage('basic_password', 'Password provided with no username.')
     http_auth = (options['basic_user'], options['basic_password']) if options['basic_user'] else None
 
-    if options['basic_user2'] and options['basic_password2'] is None:
+    if options['failover_basic_user'] and options['failover_basic_password'] is None:
         raise click.BadOptionUsage('basic_user', 'Secondary username provided with no password.')
-    elif options['basic_user2'] is None and options['basic_password2']:
+    elif options['failover_basic_user'] is None and options['failover_basic_password']:
         raise click.BadOptionUsage('basic_password', 'Secondary password provided with no username.')
     http_auth_failover = (options['failover_basic_user'], options['failover_basic_password']) if options['failover_basic_user'] else None
 
@@ -617,6 +624,7 @@ def cli(**options):
                                  client_cert=options['client_cert'],
                                  client_key=options['client_key'],
                                  headers=options['header'],
+                                 headers_failover=options['failover_header'],
                                  http_auth=http_auth,
                                  http_auth_failover=http_auth_failover,
                                  verify_certs=bool(options['ca_certs']))

--- a/prometheus_es_exporter/__init__.py
+++ b/prometheus_es_exporter/__init__.py
@@ -426,29 +426,26 @@ def create_es_client(es_cluster, ca_certs, client_cert, client_key, headers,
                 http_auth=auth
             )
 
-    def check_cluster_health(client):
+    def check_auth_credentials(client):
         try:
             # Checking the _cluster/health endpoint (GET request)
-            health = client.cluster.health(request_timeout=10)
+            client.cluster.health(request_timeout=10)
             return True
         except Exception as e:
-            log.error("Cluster health check failed: %s", e)
+            log.warning("Cluster health check failed: %s", e)
             return False
 
     es_client = instantiate_client(http_auth, headers)
-    try:
-        if not check_cluster_health(es_client):
-            raise Exception("Cluster health check failed for auth credentials.")
-    except Exception as e:
-        log.error("Authentication failed: %s", e)
-        if http_auth_failover:
-            log.error("Falling back to failover auth credentials.")
+
+    if not check_auth_credentials(es_client):
+        if http_auth_failover or headers_failover:
+            log.warning("Primary credentials failed. Falling back to failover credentials.")
             es_client = instantiate_client(http_auth_failover, headers_failover)
-            if not check_cluster_health(es_client):
+            if not check_auth_credentials(es_client):
                 raise Exception("Cluster health check failed for failover credentials as well. Abort!")
         else:
-            # No secondary credentials provided
-            raise
+            # No failover credentials provided
+            raise Exception("Authentication failed: primary credentials invalid and no failover credentials available.")
 
     return es_client
 
@@ -580,9 +577,9 @@ def cli(**options):
     http_auth = (options['basic_user'], options['basic_password']) if options['basic_user'] else None
 
     if options['failover_basic_user'] and options['failover_basic_password'] is None:
-        raise click.BadOptionUsage('basic_user', 'Secondary username provided with no password.')
+        raise click.BadOptionUsage('failover_basic_user', 'Secondary username provided with no password.')
     elif options['failover_basic_user'] is None and options['failover_basic_password']:
-        raise click.BadOptionUsage('basic_password', 'Secondary password provided with no username.')
+        raise click.BadOptionUsage('failover_basic_password', 'Secondary password provided with no username.')
     http_auth_failover = (options['failover_basic_user'], options['failover_basic_password']) if options['failover_basic_user'] else None
 
     if not options['ca_certs'] and options['client_cert']:

--- a/prometheus_es_exporter/__init__.py
+++ b/prometheus_es_exporter/__init__.py
@@ -402,6 +402,49 @@ CONFIGPARSER_CONVERTERS = {
     'enum': configparser_enum_conv(('preserve', 'drop', 'zero'))
 }
 
+def create_es_client(es_cluster, ca_certs, client_cert, client_key, headers,
+                     primary_auth, secondary_auth, verify_certs=True):
+    """
+    Create an Elasticsearch client using primary credentials,
+    falling back to secondary credentials if necessary.
+    """
+    def instantiate_client(auth):
+        if ca_certs:
+            return Elasticsearch(
+                es_cluster,
+                verify_certs=True,
+                ca_certs=ca_certs,
+                client_cert=client_cert,
+                client_key=client_key,
+                headers=headers,
+                http_auth=auth
+            )
+        else:
+            return Elasticsearch(
+                es_cluster,
+                verify_certs=verify_certs,
+                headers=headers,
+                http_auth=auth
+            )
+
+    # Try primary credentials first.
+    es_client = instantiate_client(primary_auth)
+    try:
+        if not es_client.ping():
+            raise Exception("Ping failed for primary basic auth credentials.")
+    except Exception as e:
+        log.warning("Primary authentication failed: %s", e)
+        if secondary_auth:
+            log.info("Falling back to secondary credentials.")
+            es_client = instantiate_client(secondary_auth)
+            if not es_client.ping():
+                raise Exception("Ping failed for secondary basic auth credentials as well.")
+        else:
+            # No secondary credentials provided
+            raise
+
+    return es_client
+
 
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.option('--es-cluster', '-e', default='localhost',
@@ -424,11 +467,17 @@ CONFIGPARSER_CONVERTERS = {
                    'Can be absolute, or relative to the current working directory. '
                    'Must be specified if "--client-cert" is provided.')
 @click.option('--basic-user',
-              help='Username for basic authentication with nodes. '
+              help='Primary username for basic authentication with nodes. '
                    'If not specified, basic authentication is disabled.')
 @click.option('--basic-password',
-              help='Password for basic authentication with nodes. '
-                   'Must be specified if "--basic-user" is provided.')
+              help='Primary password for basic authentication with nodes. '
+                   'Must be provided if --basic-user is specified.')
+@click.option('--basic-user2',
+              help='Secondary username for basic authentication with nodes. '
+                   'Used as a fallback if primary authentication fails.')
+@click.option('--basic-password2',
+              help='Secondary password for basic authentication with nodes. '
+                   'Must be provided if --basic-user2 is specified.')
 @click.option('--header', '-H',
               multiple=True,
               callback=http_headers_parser,
@@ -514,10 +563,13 @@ def cli(**options):
         raise click.BadOptionUsage('basic_user', 'Username provided with no password.')
     elif options['basic_user'] is None and options['basic_password']:
         raise click.BadOptionUsage('basic_password', 'Password provided with no username.')
-    elif options['basic_user']:
-        http_auth = (options['basic_user'], options['basic_password'])
-    else:
-        http_auth = None
+    http_auth = (options['basic_user'], options['basic_password']) if options['basic_user'] else None
+
+    if options['basic_user2'] and options['basic_password2'] is None:
+        raise click.BadOptionUsage('basic_user', 'Secondary username provided with no password.')
+    elif options['basic_user2'] is None and options['basic_password2']:
+        raise click.BadOptionUsage('basic_password', 'Secondary password provided with no username.')
+    http_auth2 = (options['basic_user2'], options['basic_password2']) if options['basic_user2'] else None
 
     if not options['ca_certs'] and options['client_cert']:
         raise click.BadOptionUsage('client_cert',
@@ -562,19 +614,14 @@ def cli(**options):
     port = options['port']
     es_cluster = options['es_cluster'].split(',')
 
-    if options['ca_certs']:
-        es_client = Elasticsearch(es_cluster,
-                                  verify_certs=True,
-                                  ca_certs=options['ca_certs'],
-                                  client_cert=options['client_cert'],
-                                  client_key=options['client_key'],
-                                  headers=options['header'],
-                                  http_auth=http_auth)
-    else:
-        es_client = Elasticsearch(es_cluster,
-                                  verify_certs=False,
-                                  headers=options['header'],
-                                  http_auth=http_auth)
+    es_client = create_es_client(es_cluster,
+                                 ca_certs=options['ca_certs'],
+                                 client_cert=options['client_cert'],
+                                 client_key=options['client_key'],
+                                 headers=options['header'],
+                                 primary_auth=http_auth,
+                                 secondary_auth=http_auth2,
+                                 verify_certs=bool(options['ca_certs']))
 
     scheduler = None
 

--- a/prometheus_es_exporter/__init__.py
+++ b/prometheus_es_exporter/__init__.py
@@ -403,10 +403,9 @@ CONFIGPARSER_CONVERTERS = {
 }
 
 def create_es_client(es_cluster, ca_certs, client_cert, client_key, headers,
-                     primary_auth, secondary_auth, verify_certs=True):
+                     http_auth, http_auth_failover, verify_certs=True):
     """
-    Create an Elasticsearch client using primary credentials,
-    falling back to secondary credentials if necessary.
+    Create an Elasticsearch client with the provided parameters.
     """
     def instantiate_client(auth):
         if ca_certs:
@@ -427,18 +426,17 @@ def create_es_client(es_cluster, ca_certs, client_cert, client_key, headers,
                 http_auth=auth
             )
 
-    # Try primary credentials first.
-    es_client = instantiate_client(primary_auth)
+    es_client = instantiate_client(http_auth)
     try:
         if not es_client.ping():
-            raise Exception("Ping failed for primary basic auth credentials.")
+            raise Exception("Ping failed for basic auth credentials.")
     except Exception as e:
-        log.warning("Primary authentication failed: %s", e)
-        if secondary_auth:
-            log.info("Falling back to secondary credentials.")
-            es_client = instantiate_client(secondary_auth)
+        log.warning("Authentication failed: %s", e)
+        if http_auth_failover:
+            log.info("Falling back to failover basic auth credentials.")
+            es_client = instantiate_client(http_auth_failover)
             if not es_client.ping():
-                raise Exception("Ping failed for secondary basic auth credentials as well.")
+                raise Exception("Ping failed for failover basic auth credentials as well.")
         else:
             # No secondary credentials provided
             raise
@@ -472,12 +470,12 @@ def create_es_client(es_cluster, ca_certs, client_cert, client_key, headers,
 @click.option('--basic-password',
               help='Primary password for basic authentication with nodes. '
                    'Must be provided if --basic-user is specified.')
-@click.option('--basic-user2',
+@click.option('--failover-basic-user',
               help='Secondary username for basic authentication with nodes. '
                    'Used as a fallback if primary authentication fails.')
-@click.option('--basic-password2',
+@click.option('--failover-basic-password',
               help='Secondary password for basic authentication with nodes. '
-                   'Must be provided if --basic-user2 is specified.')
+                   'Must be provided if --failover-basic-user is specified.')
 @click.option('--header', '-H',
               multiple=True,
               callback=http_headers_parser,
@@ -569,7 +567,7 @@ def cli(**options):
         raise click.BadOptionUsage('basic_user', 'Secondary username provided with no password.')
     elif options['basic_user2'] is None and options['basic_password2']:
         raise click.BadOptionUsage('basic_password', 'Secondary password provided with no username.')
-    http_auth2 = (options['basic_user2'], options['basic_password2']) if options['basic_user2'] else None
+    http_auth_failover = (options['failover_basic_user'], options['failover_basic_password']) if options['failover_basic_user'] else None
 
     if not options['ca_certs'] and options['client_cert']:
         raise click.BadOptionUsage('client_cert',
@@ -619,8 +617,8 @@ def cli(**options):
                                  client_cert=options['client_cert'],
                                  client_key=options['client_key'],
                                  headers=options['header'],
-                                 primary_auth=http_auth,
-                                 secondary_auth=http_auth2,
+                                 http_auth=http_auth,
+                                 http_auth_failover=http_auth_failover,
                                  verify_certs=bool(options['ca_certs']))
 
     scheduler = None


### PR DESCRIPTION
- Introduced `--failover-basic-user`, `--failover-basic-password` and `--failover-headers` CLI options for secondary credentials.
- Refactored Elasticsearch client creation into a dedicated helper function.
