### PR TITLE
fix: Correct Dockerfile to ensure proper module installation and execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,15 @@ WORKDIR /usr/src/app
 
 COPY setup.py /usr/src/app/
 COPY README.md /usr/src/app/
+COPY LICENSE /usr/src/app/
+
 RUN python -m pip install --upgrade pip
+
+COPY prometheus_es_exporter/ /usr/src/app/prometheus_es_exporter/
+
 # Elasticsearch switched to a non open source license from version 7.11 onwards.
 # Limit to earlier versions to avoid license and compatibility issues.
 RUN pip install -e . 'elasticsearch<7.11'
-
-COPY prometheus_es_exporter/*.py /usr/src/app/prometheus_es_exporter/
-COPY LICENSE /usr/src/app/
 
 EXPOSE 9206
 


### PR DESCRIPTION
Currently, the container fails to start because it cannot locate the prometheus_es_exporter module. Reordering the commands resolves the issue.

Error log:

```
Traceback (most recent call last):
  File "/usr/local/bin/prometheus-es-exporter", line 5, in <module>
    from prometheus_es_exporter import main
ModuleNotFoundError: No module named 'prometheus_es_exporter'
```
